### PR TITLE
feat: redesign about dialog and refine feedback actions

### DIFF
--- a/cypress/e2e/quick-help.cy.ts
+++ b/cypress/e2e/quick-help.cy.ts
@@ -4,20 +4,24 @@ describe("Quick help", () => {
     cy.visitApp();
   });
 
-  describe("help tooltip", () => {
-    it("opens the quick help content", () => {
+  describe("about dialog", () => {
+    it("opens the about dialog content", () => {
       cy.openQuickHelp();
-      cy.getByTestId("quick-help-tooltip").should("contain.text", "Quick help");
-      cy.getByTestId("quick-help-tooltip").should("contain.text", "Tempo slider");
-      cy.getByTestId("quick-help-tooltip").should("contain.text", "Beat selector");
+      cy.getByTestId("quick-help-dialog").should("be.visible");
+      cy.getByTestId("quick-help-dialog").should("contain.text", "About & Help");
+      cy.getByTestId("quick-help-dialog").should("contain.text", "Our Story");
+      cy.getByTestId("quick-help-dialog").should("contain.text", "Quick Start");
+      cy.getByTestId("quick-help-dialog").should("contain.text", "Made with Heart");
+      cy.getByTestId("quick-help-dialog").should("contain.text", "Issues");
+      cy.getByTestId("quick-help-dialog").should("contain.text", "Feedback");
     });
 
-    it("closes the tooltip when clicking away", () => {
+    it("closes the dialog when pressing the close button", () => {
       cy.openQuickHelp();
-      cy.getByTestId("quick-help-tooltip").should("be.visible");
+      cy.getByTestId("quick-help-dialog").should("be.visible");
 
-      cy.getByTestId("app-brand").click();
-      cy.getByTestId("quick-help-tooltip").should("not.exist");
+      cy.getByTestId("quick-help-close").click();
+      cy.getByTestId("quick-help-dialog").should("not.exist");
     });
   });
 });

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,4 +1,5 @@
 import { css } from "@linaria/core";
+import strings from "../../strings.json";
 
 const footerContainer = css`
 //   width: fit-content;
@@ -21,13 +22,12 @@ const descriptionText = css`
 `;
 
 export const Footer = () => {
+  const { title, description } = strings.footer;
   return (
     <div className={footerContainer}>
-      "<i>Horsenome</i>" Made with ❤️
+      {title}
       <div className={descriptionText}>
-        Horsenome brings the rhythm of nature into music, inspired by the steady
-        gallop of a horse 🐎 and the resonant beats of the dholak's thappi. Feel
-        the rhythm, embrace the melody, and let your creativity flow!
+        {description}
       </div>
     </div>
   );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,10 +1,22 @@
-import { HTMLAttributes, useState } from "react";
 import { css } from "@linaria/core";
-import Tooltip from "@mui/material/Tooltip";
+import AutoAwesomeRoundedIcon from "@mui/icons-material/AutoAwesomeRounded";
+import BugReportRoundedIcon from "@mui/icons-material/BugReportRounded";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import MailRoundedIcon from "@mui/icons-material/MailRounded";
+import PlayCircleRoundedIcon from "@mui/icons-material/PlayCircleRounded";
+import TuneRoundedIcon from "@mui/icons-material/TuneRounded";
+import Button from "@mui/material/Button";
+import Box from "@mui/material/Box";
+import Dialog from "@mui/material/Dialog";
+import DialogContent from "@mui/material/DialogContent";
 import IconButton from "@mui/material/IconButton";
-import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
-import ClickAwayListener from "@mui/material/ClickAwayListener";
+import Link from "@mui/material/Link";
+import Stack from "@mui/material/Stack";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import { useId, useState } from "react";
+import strings from "../../strings.json";
 
 const headerContainer = css`
   width: 100%;
@@ -20,15 +32,106 @@ const brand = css`
   color: #3b6934;
 `;
 
+const sectionStack = css`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+const sectionTitle = css`
+  color: #3b6934;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+`;
+
+const actionRow = css`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+`;
+
+const dialogBody = css`
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 24px;
+
+  @media (min-width: 640px) {
+    grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+    gap: 28px;
+    align-items: start;
+  }
+`;
+
+const dialogColumn = css`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+const quickStartList = css`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const quickStartItem = css`
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+`;
+
+const quickStartIconWrap = css`
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #bfe0b2;
+  color: #325f2c;
+`;
+
+const supportCard = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 28px 20px;
+  border-radius: 28px;
+  background: #f2f4f2;
+`;
+
 export const Header = () => {
   const [open, setOpen] = useState(false);
-  const handleTooltipOpen = () => {
+  const dialogTitleId = useId();
+  const dialogDescriptionId = useId();
+  const {
+    brand: brandLabel,
+    quickHelp: {
+      triggerAriaLabel,
+      dialog: {
+        actions,
+        badgeLabel,
+        closeAriaLabel,
+        description,
+        quickStart,
+        supportCard: supportCardContent,
+        title,
+      },
+    },
+  } = strings.header;
+
+  const handleDialogOpen = () => {
     setOpen(true);
   };
 
-  const handleTooltipClose = () => {
+  const handleDialogClose = () => {
     setOpen(false);
   };
+
   return (
     <header className={headerContainer}>
       <div className={brand} data-testid="app-brand">
@@ -41,69 +144,212 @@ export const Header = () => {
             letterSpacing: "-0.03em",
           }}
         >
-          Horsenome
+          {brandLabel}
         </Typography>
       </div>
-      <ClickAwayListener onClickAway={handleTooltipClose}>
-        <Tooltip
-          open={open}
-          disableHoverListener
-          disableFocusListener
-          disableInteractive
-          title={
-            <>
-              <Typography variant="subtitle2" gutterBottom sx={{ fontWeight: 700 }}>
-                Quick help
-              </Typography>
-              <Typography variant="body1" gutterBottom>
-                <b>Tempo slider</b>
-                <br />
-                Set the BPM.
-              </Typography>
-              <Typography variant="body1" gutterBottom>
-                <b>Beat selector</b>
-                <br />
-                Pick a taal or meter.
-              </Typography>
-              <Typography variant="body1">
-                <b>Start/Stop</b>
-                <br />
-                Begin or pause playback.
-              </Typography>
-            </>
-          }
-          onClick={handleTooltipOpen}
-          onTouchStart={(e) => {
-            e.preventDefault(); // Prevent unintended events
-            handleTooltipOpen();
-          }}
-          onDoubleClick={() => setOpen(!open)}
-          onMouseLeave={handleTooltipClose}
-          slotProps={{
-            popper: {
-              disablePortal: true,
-            },
-            tooltip: {
-              ...( { "data-testid": "quick-help-tooltip" } as HTMLAttributes<HTMLDivElement> ),
-            },
-          }}
-        >
+
+      <IconButton
+        aria-label={triggerAriaLabel}
+        data-testid="quick-help-trigger"
+        onClick={handleDialogOpen}
+        sx={{
+          width: { xs: 40, sm: 36 },
+          height: { xs: 40, sm: 36 },
+          color: "#3b6934",
+          "&:hover": {
+            backgroundColor: "rgba(59, 105, 52, 0.08)",
+          },
+        }}
+      >
+        <InfoOutlinedIcon sx={{ fontSize: 22 }} />
+      </IconButton>
+
+      <Dialog
+        open={open}
+        onClose={handleDialogClose}
+        aria-labelledby={dialogTitleId}
+        aria-describedby={dialogDescriptionId}
+        fullWidth
+        maxWidth="xs"
+        PaperProps={{
+          "data-testid": "quick-help-dialog",
+          sx: {
+            borderRadius: { xs: 4, sm: 5 },
+            width: "min(100%, 640px)",
+            maxWidth: "640px",
+            overflow: "hidden",
+            boxShadow: "0 40px 100px -20px rgba(25, 28, 27, 0.15)",
+          },
+        }}
+      >
+        <DialogContent sx={{ px: { xs: 3.5, sm: 4 }, py: { xs: 3.5, sm: 4 } }}>
           <IconButton
-            aria-label="quick help"
-            data-testid="quick-help-trigger"
+            aria-label={closeAriaLabel}
+            onClick={handleDialogClose}
+            data-testid="quick-help-close"
             sx={{
-              width: 32,
-              height: 32,
-              color: "#3b6934",
+              position: "absolute",
+              top: 20,
+              right: 20,
+              width: 44,
+              height: 44,
+              backgroundColor: "#eff1ef",
+              color: "#556158",
               "&:hover": {
-                backgroundColor: "rgba(59, 105, 52, 0.08)",
+                backgroundColor: "#e1e3e1",
               },
             }}
           >
-            <HelpOutlineIcon sx={{ fontSize: 20 }} />
+            <CloseRoundedIcon />
           </IconButton>
-        </Tooltip>
-      </ClickAwayListener>
+
+          <div className={dialogBody}>
+            <div className={dialogColumn}>
+              <Stack spacing={1.5} sx={{ pr: { xs: 6, sm: 1 } }}>
+                <AutoAwesomeRoundedIcon sx={{ fontSize: 34, color: "#3b6934" }} />
+                <Typography
+                  id={dialogTitleId}
+                  sx={{
+                    color: "#3b6934",
+                    fontWeight: 800,
+                    fontSize: { xs: "1.95rem", sm: "2.2rem" },
+                    lineHeight: 1.02,
+                    letterSpacing: "-0.03em",
+                    whiteSpace: { xs: "normal", sm: "nowrap" },
+                  }}
+                >
+                  {title}
+                </Typography>
+              </Stack>
+
+              <div className={sectionStack}>
+                <Typography className={sectionTitle}>{badgeLabel}</Typography>
+                <Typography
+                  id={dialogDescriptionId}
+                  variant="body2"
+                  sx={{
+                    color: "rgba(65, 73, 67, 0.92)",
+                    lineHeight: 1.55,
+                    fontWeight: 500,
+                    fontSize: { xs: "0.95rem", sm: "0.98rem" },
+                    maxWidth: { xs: "100%", sm: "25ch" },
+                  }}
+                >
+                  {description}
+                </Typography>
+              </div>
+
+              <Box className={supportCard}>
+                <Typography sx={{ fontSize: "1.35rem", lineHeight: 1 }}>❤️</Typography>
+                <Typography sx={{ fontWeight: 800, color: "#191c1b" }}>
+                  {supportCardContent.title}
+                </Typography>
+                <Typography
+                  variant="body2"
+                  sx={{ color: "rgba(85, 97, 88, 0.9)", textAlign: "center" }}
+                >
+                  {supportCardContent.body}
+                </Typography>
+              </Box>
+            </div>
+
+            <div className={dialogColumn}>
+              <div className={sectionStack}>
+                <Typography className={sectionTitle}>{quickStart.title}</Typography>
+                <div className={quickStartList}>
+                  {quickStart.items.map((item, index) => {
+                    const icon = index === 0
+                      ? <TuneRoundedIcon sx={{ fontSize: 18 }} />
+                      : index === 1
+                        ? <AutoAwesomeRoundedIcon sx={{ fontSize: 18 }} />
+                        : index === 2
+                          ? <TuneRoundedIcon sx={{ fontSize: 18 }} />
+                          : <PlayCircleRoundedIcon sx={{ fontSize: 18 }} />;
+
+                    return (
+                      <div className={quickStartItem} key={item}>
+                        <div className={quickStartIconWrap}>{icon}</div>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            color: "rgba(65, 73, 67, 0.84)",
+                            lineHeight: 1.45,
+                            fontSize: { xs: "0.88rem", sm: "0.92rem" },
+                            pt: 0.4,
+                            maxWidth: "24ch",
+                          }}
+                        >
+                          {item}
+                        </Typography>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className={actionRow}>
+                <Tooltip title="Open GitHub issues" placement="top">
+                  <Button
+                    component={Link}
+                    href={actions.feedbackHref}
+                    target="_blank"
+                    rel="noreferrer"
+                    variant="contained"
+                    color="success"
+                    startIcon={<BugReportRoundedIcon />}
+                    sx={{
+                      minHeight: 56,
+                      borderRadius: "18px",
+                      fontWeight: 800,
+                      textTransform: "none",
+                      fontSize: { xs: "0.98rem", sm: "1rem" },
+                      whiteSpace: "nowrap",
+                      px: { xs: 2, sm: 2.5 },
+                      justifyContent: "center",
+                      boxShadow: "0 12px 24px rgba(59, 105, 52, 0.18)",
+                      "& .MuiButton-startIcon": {
+                        mr: 0.8,
+                      },
+                    }}
+                  >
+                    {actions.feedbackLabel}
+                  </Button>
+                </Tooltip>
+                <Tooltip title="Send email feedback" placement="top">
+                  <Button
+                    component={Link}
+                    href={actions.supportHref}
+                    variant="contained"
+                    startIcon={<MailRoundedIcon />}
+                    sx={{
+                      minHeight: 56,
+                      borderRadius: "18px",
+                      fontWeight: 800,
+                      textTransform: "none",
+                      fontSize: { xs: "0.98rem", sm: "1rem" },
+                      whiteSpace: "nowrap",
+                      px: { xs: 2, sm: 2.5 },
+                      justifyContent: "center",
+                      backgroundColor: "#eceeec",
+                      color: "#2e3130",
+                      boxShadow: "none",
+                      "& .MuiButton-startIcon": {
+                        mr: 0.8,
+                      },
+                      "&:hover": {
+                        backgroundColor: "#e1e3e1",
+                        boxShadow: "none",
+                      },
+                    }}
+                  >
+                    {actions.supportLabel}
+                  </Button>
+                </Tooltip>
+              </div>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </header>
   );
 };

--- a/src/components/Metronome/BPMControl.tsx
+++ b/src/components/Metronome/BPMControl.tsx
@@ -2,6 +2,7 @@ import { HTMLAttributes } from "react";
 import { Slider } from "@mui/material";
 import { css } from "@linaria/core";
 import { useMetronome } from "../../hooks/useMetronome";
+import strings from "../../strings.json";
 
 const bpmControlContainer = css`
   display: flex;
@@ -36,6 +37,7 @@ const sliderRoot = css`
 
 const BPMControl = () => {
   const { bpm, setBpm } = useMetronome();
+  const { ariaLabel } = strings.metronome.bpmControl;
 
   return (
     <div className={bpmControlContainer}>
@@ -45,7 +47,7 @@ const BPMControl = () => {
         value={bpm}
         onChange={(_, value) => setBpm(value as number)}
         valueLabelDisplay="off"
-        aria-label="tempo"
+        aria-label={ariaLabel}
         className={sliderRoot}
         data-testid="bpm-slider"
         slotProps={{

--- a/src/components/Metronome/BeatControl.tsx
+++ b/src/components/Metronome/BeatControl.tsx
@@ -12,6 +12,7 @@ import {
 } from "./constant";
 import MobileBeatControl from "./MobileBeatControl";
 import DesktopBeatControl from "./DesktopBeatControl";
+import strings from "../../strings.json";
 
 const beatControl = css`
   width: 100%;
@@ -77,6 +78,7 @@ const BeatControl = () => {
   const [showCustom, setShowCustom] = useState(false);
   const [customBeats, setCustomBeats] = useState(String(timeSignature.beats));
   const [customUnit, setCustomUnit] = useState(String(timeSignature.unit));
+  const { beatsAriaLabel, unitAriaLabel, label: customLabelText } = strings.metronome.beatControl.custom;
 
   const selectedValue = useMemo(() => {
     const preset = DEFAULT_METER_PRESETS.find(
@@ -162,7 +164,7 @@ const BeatControl = () => {
                   min={CUSTOM_METER_LIMITS.min}
                   max={CUSTOM_METER_LIMITS.max}
                   value={customBeats}
-                  aria-label="matras in cycle"
+                  aria-label={beatsAriaLabel}
                   onChange={(event) => setCustomBeats(event.target.value)}
                   onBlur={() => applyCustomMeter(customBeats, customUnit)}
                 />
@@ -174,12 +176,12 @@ const BeatControl = () => {
                   min={CUSTOM_METER_LIMITS.min}
                   max={CUSTOM_METER_LIMITS.max}
                   value={customUnit}
-                  aria-label="beat unit"
+                  aria-label={unitAriaLabel}
                   onChange={(event) => setCustomUnit(event.target.value)}
                   onBlur={() => applyCustomMeter(customBeats, customUnit)}
                 />
               </div>
-              <span className={customLabel} data-testid="custom-meter-label">Custom</span>
+              <span className={customLabel} data-testid="custom-meter-label">{customLabelText}</span>
             </div>
           </motion.div>
         ) : null}

--- a/src/components/Metronome/DesktopBeatControl.tsx
+++ b/src/components/Metronome/DesktopBeatControl.tsx
@@ -3,6 +3,7 @@ import { Box, Chip, Stack, Typography } from "@mui/material";
 import { motion } from "framer-motion";
 import { css } from "@linaria/core";
 import { DEFAULT_METER_PRESETS, PROTOTYPE_TERTIARY_TEXT } from "./constant";
+import strings from "../../strings.json";
 
 const chipRow = css`
   justify-content: center;
@@ -22,13 +23,14 @@ const DesktopBeatControl = ({
   onPresetSelect,
   onToggleCustom,
 }: DesktopBeatControlProps) => {
+  const { meterAriaLabel, custom: { toggleAriaLabel } } = strings.metronome.beatControl;
   return (
     <Stack
       direction="row"
       spacing={1.5}
       useFlexGap
       className={chipRow}
-      aria-label="meter"
+      aria-label={meterAriaLabel}
       data-testid="desktop-meter-control"
     >
       {DEFAULT_METER_PRESETS.map((option) => (
@@ -80,7 +82,7 @@ const DesktopBeatControl = ({
       ))}
       <Chip
         clickable
-        aria-label="custom meter"
+        aria-label={toggleAriaLabel}
         onClick={onToggleCustom}
         data-testid="custom-meter-toggle"
         data-selected={showCustom ? "true" : "false"}

--- a/src/components/Metronome/FloatingButton.tsx
+++ b/src/components/Metronome/FloatingButton.tsx
@@ -2,15 +2,17 @@ import Box from '@mui/material/Box';
 import Fab from '@mui/material/Fab';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
+import strings from "../../strings.json";
 
 
 export default function FloatingActionButtons() {
+  const { addAriaLabel, editAriaLabel } = strings.floatingButton;
   return (
     <Box>
-      <Fab color="primary" aria-label="add">
+      <Fab color="primary" aria-label={addAriaLabel}>
         <AddIcon />
       </Fab>
-      <Fab color="secondary" aria-label="edit">
+      <Fab color="secondary" aria-label={editAriaLabel}>
         <EditIcon />
       </Fab>
     </Box>

--- a/src/components/Metronome/HistoryPanel.tsx
+++ b/src/components/Metronome/HistoryPanel.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useMetronome } from "../../hooks/useMetronome";
+import strings from "../../strings.json";
 
 const panel = css`
   display: flex;
@@ -38,15 +39,16 @@ const toneStyles: Record<string, string> = {
 
 const HistoryPanel = () => {
   const { history } = useMetronome();
+  const { description, title } = strings.metronome.history;
 
   return (
     <Paper elevation={0} className={panel}>
       <Box>
         <Typography variant="overline" sx={{ letterSpacing: "0.24em", color: "rgba(31, 42, 29, 0.55)" }}>
-          History
+          {title}
         </Typography>
         <Typography variant="body2" sx={{ color: "rgba(31, 42, 29, 0.6)" }}>
-          Recent tempo changes and playback actions.
+          {description}
         </Typography>
       </Box>
       <List className={historyList}>

--- a/src/components/Metronome/Metronome.tsx
+++ b/src/components/Metronome/Metronome.tsx
@@ -9,6 +9,7 @@ import BeatControl from "./BeatControl";
 import RhythmControl from "./RhythmControl";
 import StartStopButton from "./StartStopButton";
 import { useMetronome } from "../../hooks/useMetronome";
+import strings from "../../strings.json";
 
 const TickTockAnimation = lazy(() => import("../TickTock"));
 
@@ -151,6 +152,11 @@ const fallbackLabel = css`
 
 const Metronome = () => {
   const { bpm } = useMetronome();
+  const {
+    bpmCaption: bpmCaptionLabel,
+    actionLabels,
+    visualizerFallback: visualizerFallbackLabel,
+  } = strings.metronome;
 
   return (
     <div className={metronomeSection} data-testid="metronome-root">
@@ -180,7 +186,7 @@ const Metronome = () => {
         >
           {bpm}
         </Typography>
-        <Typography className={bpmCaption}>Beats Per Minute</Typography>
+        <Typography className={bpmCaption}>{bpmCaptionLabel}</Typography>
       </div>
 
       <div className={transport}>
@@ -195,15 +201,15 @@ const Metronome = () => {
       <div className={actionRow}>
         <div className={actionItem}>
           <VolumeUpOutlinedIcon sx={{ fontSize: 20 }} />
-          <Typography className={actionLabel}>Volume</Typography>
+          <Typography className={actionLabel}>{actionLabels.volume}</Typography>
         </div>
         <div className={actionItem} style={{ color: "#9db89e" }}>
           <VibrationOutlinedIcon sx={{ fontSize: 20 }} />
-          <Typography className={actionLabel}>Haptic</Typography>
+          <Typography className={actionLabel}>{actionLabels.haptic}</Typography>
         </div>
         <div className={actionItem}>
           <TimerOutlinedIcon sx={{ fontSize: 20 }} />
-          <Typography className={actionLabel}>Timer</Typography>
+          <Typography className={actionLabel}>{actionLabels.timer}</Typography>
         </div>
       </div>
 
@@ -211,7 +217,7 @@ const Metronome = () => {
         <Suspense
           fallback={(
             <div className={visualizerFallback}>
-              <span className={fallbackLabel}>Loading visualizer</span>
+              <span className={fallbackLabel}>{visualizerFallbackLabel}</span>
             </div>
           )}
         >

--- a/src/components/Metronome/MetronomeProvider/MetronomeProvider.tsx
+++ b/src/components/Metronome/MetronomeProvider/MetronomeProvider.tsx
@@ -21,8 +21,17 @@ import {
   getSubdivisionCount,
   RhythmMode,
 } from "../constant";
+import strings from "../../../strings.json";
 
 export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const {
+    initialLabel,
+    meterUpdatedLabel,
+    rhythmUpdatedLabel,
+    startedLabel,
+    stoppedLabel,
+    tempoUpdatedLabel,
+  } = strings.metronome.history;
   const [bpm, setBpmState] = useState(120);
   const [timeSignature, setTimeSignatureState] = useState<TimeSignature>({
     beats: DEFAULT_METER_PRESET.beats,
@@ -34,7 +43,7 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
   const [history, setHistory] = useState<HistoryEntry[]>([
     {
       id: "initial",
-      label: "Ready",
+      label: initialLabel,
       detail: `120 BPM · ${DEFAULT_METER_PRESET.label}`,
       tone: "neutral",
     },
@@ -133,7 +142,7 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
     playPulse();
     scheduleNextPulse();
     pushHistory({
-      label: "Started",
+      label: startedLabel,
       detail: getPlaybackDetail(timeSignature.beats, timeSignature.unit, bpm, rhythmMode),
       tone: "success",
     });
@@ -145,6 +154,7 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
     pushHistory,
     rhythmMode,
     scheduleNextPulse,
+    startedLabel,
     timeSignature.beats,
     timeSignature.unit,
   ]);
@@ -156,7 +166,7 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
     clearPlaybackTimer();
 
     pushHistory({
-      label: "Stopped",
+      label: stoppedLabel,
       detail: getPlaybackDetail(timeSignature.beats, timeSignature.unit, bpm, rhythmMode),
       tone: "neutral",
     });
@@ -166,6 +176,7 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
     getPlaybackDetail,
     pushHistory,
     rhythmMode,
+    stoppedLabel,
     timeSignature.beats,
     timeSignature.unit,
   ]);
@@ -174,12 +185,12 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
     (nextBpm: number) => {
       setBpmState(nextBpm);
       pushHistory({
-        label: "Tempo updated",
+        label: tempoUpdatedLabel,
         detail: `${nextBpm} BPM`,
         tone: "accent",
       });
     },
-    [pushHistory]
+    [pushHistory, tempoUpdatedLabel]
   );
 
   const setTimeSignature = useCallback(
@@ -190,12 +201,12 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
       subdivisionStepRef.current = 0;
 
       pushHistory({
-        label: "Meter updated",
+        label: meterUpdatedLabel,
         detail: `${signature.beats}/${signature.unit}`,
         tone: "accent",
       });
     },
-    [pushHistory]
+    [meterUpdatedLabel, pushHistory]
   );
 
   const setRhythmMode = useCallback(
@@ -206,12 +217,12 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
       subdivisionStepRef.current = 0;
 
       pushHistory({
-        label: "Rhythm updated",
+        label: rhythmUpdatedLabel,
         detail: getRhythmLabel(mode),
         tone: "accent",
       });
     },
-    [pushHistory]
+    [pushHistory, rhythmUpdatedLabel]
   );
 
   useEffect(() => {

--- a/src/components/Metronome/MobileBeatControl.tsx
+++ b/src/components/Metronome/MobileBeatControl.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
 } from "@mui/material";
 import { DEFAULT_METER_PRESETS, PROTOTYPE_TERTIARY_TEXT } from "./constant";
+import strings from "../../strings.json";
 
 const mobileSelectorWrap = css`
   width: min(100%, 280px);
@@ -37,6 +38,7 @@ const MobileBeatControl = ({
   selectedWesternNotation,
   onPresetSelect,
 }: MobileBeatControlProps) => {
+  const { meterAriaLabel, custom: { label: customLabelText } } = strings.metronome.beatControl;
   return (
     <div className={mobileSelectorWrap}>
       <FormControl fullWidth>
@@ -45,7 +47,7 @@ const MobileBeatControl = ({
           displayEmpty
           onChange={(event: SelectChangeEvent<string>) => onPresetSelect(event.target.value)}
           IconComponent={ExpandMoreIcon}
-          aria-label="meter"
+          aria-label={meterAriaLabel}
           data-testid="mobile-meter-select"
           SelectDisplayProps={
             { "data-testid": "mobile-meter-select-display" } as HTMLAttributes<HTMLDivElement>
@@ -79,7 +81,7 @@ const MobileBeatControl = ({
               {option.label}
             </MenuItem>
           ))}
-          <MenuItem value="custom" data-testid="mobile-meter-option-custom">Custom</MenuItem>
+          <MenuItem value="custom" data-testid="mobile-meter-option-custom">{customLabelText}</MenuItem>
         </Select>
       </FormControl>
       {selectedWesternNotation ? (

--- a/src/components/Metronome/RhythmControl.tsx
+++ b/src/components/Metronome/RhythmControl.tsx
@@ -20,6 +20,7 @@ import {
 } from "@mui/material";
 import { useMetronome } from "../../hooks/useMetronome";
 import { RHYTHM_OPTIONS, RhythmMode } from "./constant";
+import strings from "../../strings.json";
 
 const triggerWrap = css`
   position: fixed;
@@ -73,10 +74,16 @@ const RhythmControl = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const {
+    defaultLabel,
+    drawerTitle,
+    triggerAriaLabel,
+    triggerTooltip,
+  } = strings.metronome.rhythm;
 
   const selectedLabel = useMemo(
-    () => RHYTHM_OPTIONS.find((option) => option.value === rhythmMode)?.label ?? "Off",
-    [rhythmMode]
+    () => RHYTHM_OPTIONS.find((option) => option.value === rhythmMode)?.label ?? defaultLabel,
+    [defaultLabel, rhythmMode]
   );
 
   const handleOpen = (event: React.MouseEvent<HTMLElement>) => {
@@ -100,9 +107,9 @@ const RhythmControl = () => {
 
   return (
     <div className={triggerWrap}>
-      <Tooltip title="Rhythm settings" placement="left">
+      <Tooltip title={triggerTooltip} placement="left">
         <IconButton
-          aria-label="rhythm settings"
+          aria-label={triggerAriaLabel}
           onClick={handleOpen}
           data-testid="rhythm-trigger"
           sx={{
@@ -206,7 +213,7 @@ const RhythmControl = () => {
         <div className={drawerBody}>
           <div className={drawerHandle} />
           <Typography sx={{ px: 1.5, pb: 1.5, fontSize: "0.78rem", fontWeight: 700, letterSpacing: "0.16em", textTransform: "uppercase", color: "#717973" }}>
-            Rhythm
+            {drawerTitle}
           </Typography>
           {RHYTHM_OPTIONS.map((option) => {
             const selected = option.value === rhythmMode;

--- a/src/components/Metronome/RhythmSelector.tsx
+++ b/src/components/Metronome/RhythmSelector.tsx
@@ -11,11 +11,12 @@ import {
   FormControlLabel,
   Radio,
 } from "@mui/material";
-// import Grid from "@mui/material/Grid2";
+import strings from "../../strings.json";
 
 const RhythmSelector = () => {
   const [open, setOpen] = useState(false);
-  const [selectedRhythm, setSelectedRhythm] = useState("4/4");
+  const { cancelLabel, confirmLabel, options, title } = strings.rhythmSelector;
+  const [selectedRhythm, setSelectedRhythm] = useState(options[0]);
 
   const handleChipClick = () => setOpen(true);
   const handleDialogClose = () => setOpen(false);
@@ -40,21 +41,20 @@ const RhythmSelector = () => {
       />
 
       <Dialog open={open} onClose={handleDialogClose}>
-        <DialogTitle>Select Rhythm</DialogTitle>
+        <DialogTitle>{title}</DialogTitle>
         <DialogContent>
           <FormControl>
             <RadioGroup value={selectedRhythm} onChange={handleRhythmChange}>
-              <FormControlLabel value="4/4" control={<Radio />} label="4/4" />
-              <FormControlLabel value="3/4" control={<Radio />} label="3/4" />
-              <FormControlLabel value="6/8" control={<Radio />} label="6/8" />
-              <FormControlLabel value="7/8" control={<Radio />} label="7/8" />
+              {options.map((option) => (
+                <FormControlLabel key={option} value={option} control={<Radio />} label={option} />
+              ))}
             </RadioGroup>
           </FormControl>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleDialogClose}>Cancel</Button>
+          <Button onClick={handleDialogClose}>{cancelLabel}</Button>
           <Button onClick={handleConfirm} color="primary">
-            Confirm
+            {confirmLabel}
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/components/Metronome/StartStopButton.tsx
+++ b/src/components/Metronome/StartStopButton.tsx
@@ -3,6 +3,7 @@ import Start from "../../assets/music-player-start.svg";
 import Stop from "../../assets/music-player-stop.svg";
 import { css } from "@linaria/core";
 import { useMetronome } from "../../hooks/useMetronome";
+import strings from "../../strings.json";
 
 const playButtonStyle = css`
   width: 112px;
@@ -32,6 +33,7 @@ const playButtonStyle = css`
 
 const StartStopButton = () => {
   const { isRunning, startMetronome, stopMetronome } = useMetronome();
+  const { startAlt, startAriaLabel, stopAlt, stopAriaLabel } = strings.metronome.transport;
   const playButton = isRunning ? Stop : Start;
   const onClick = isRunning ? stopMetronome : startMetronome;
   return (
@@ -39,13 +41,13 @@ const StartStopButton = () => {
       onClick={onClick}
       className={playButtonStyle}
       size="large"
-      aria-label={isRunning ? "stop metronome" : "start metronome"}
+      aria-label={isRunning ? stopAriaLabel : startAriaLabel}
       data-testid="transport-toggle"
       sx={{
         border: "1px solid rgba(31, 42, 29, 0.08)",
       }}
     >
-      <img src={playButton} alt={isRunning ? "stop" : "start"} />
+      <img src={playButton} alt={isRunning ? stopAlt : startAlt} />
     </IconButton>
   );
 };

--- a/src/components/Metronome/constant.ts
+++ b/src/components/Metronome/constant.ts
@@ -1,3 +1,5 @@
+import strings from "../../strings.json";
+
 export type TempoLabel = {
   label: string;
   min: number;
@@ -30,92 +32,19 @@ export const CUSTOM_METER_LIMITS = {
 
 export const PROTOTYPE_TERTIARY_TEXT = "#556158";
 
-export const DEFAULT_METER_PRESETS: MeterPreset[] = [
-  {
-    label: "Teental",
-    notation: "16 matras",
-    westernNotation: "16/4",
-    value: "teental",
-    beats: 16,
-    unit: 4,
-    tradition: "hindustani",
-  },
-  {
-    label: "Ektal",
-    notation: "12 matras",
-    westernNotation: "12/4",
-    value: "ektal",
-    beats: 12,
-    unit: 4,
-    tradition: "hindustani",
-  },
-  {
-    label: "Jhaptal",
-    notation: "10 matras",
-    westernNotation: "10/4",
-    value: "jhaptal",
-    beats: 10,
-    unit: 4,
-    tradition: "hindustani",
-  },
-  {
-    label: "Rupak",
-    notation: "7 matras",
-    westernNotation: "7/4",
-    value: "rupak",
-    beats: 7,
-    unit: 4,
-    tradition: "hindustani",
-  },
-  {
-    label: "Dadra",
-    notation: "6 matras",
-    westernNotation: "6/4",
-    value: "dadra",
-    beats: 6,
-    unit: 4,
-    tradition: "hindustani",
-  },
-  {
-    label: "Keharwa",
-    notation: "8 matras",
-    westernNotation: "8/4",
-    value: "keharwa",
-    beats: 8,
-    unit: 4,
-    tradition: "hindustani",
-  },
-];
+export const DEFAULT_METER_PRESETS: MeterPreset[] = strings.metronome.meterPresets.map(
+  (preset) => ({
+    ...preset,
+    tradition: preset.tradition as MeterPreset["tradition"],
+  })
+);
 
 export const DEFAULT_METER_PRESET = DEFAULT_METER_PRESETS[0];
 
-export const RHYTHM_OPTIONS: RhythmOption[] = [
-  {
-    value: "off",
-    label: "Off",
-    caption: "Main beats only",
-  },
-  {
-    value: "duple",
-    label: "Duple",
-    caption: "2 pulses per beat",
-  },
-  {
-    value: "triplet",
-    label: "Triplet",
-    caption: "3 pulses per beat",
-  },
-  {
-    value: "quad",
-    label: "Quad",
-    caption: "4 pulses per beat",
-  },
-  {
-    value: "swing",
-    label: "Swing",
-    caption: "Long-short feel",
-  },
-];
+export const RHYTHM_OPTIONS: RhythmOption[] = strings.metronome.rhythmOptions.map((option) => ({
+  ...option,
+  value: option.value as RhythmMode,
+}));
 
 export const DEFAULT_RHYTHM_MODE: RhythmMode = "off";
 
@@ -140,23 +69,11 @@ export const getSubdivisionCount = (mode: RhythmMode) => {
 };
 
 export const getRhythmLabel = (mode: RhythmMode) => {
-  return RHYTHM_OPTIONS.find((option) => option.value === mode)?.label ?? "Off";
+  return RHYTHM_OPTIONS.find((option) => option.value === mode)?.label
+    ?? strings.metronome.rhythm.defaultLabel;
 };
 
-export const TEMPO_LABELS: TempoLabel[] = [
-  { label: "Larghissimo", min: 1, max: 24 },
-  { label: "Grave", min: 25, max: 39 },
-  { label: "Largo", min: 40, max: 54 },
-  { label: "Lento", min: 55, max: 63 },
-  { label: "Adagio", min: 64, max: 72 },
-  { label: "Andante", min: 73, max: 108 },
-  { label: "Moderato", min: 109, max: 120 },
-  { label: "Allegretto", min: 121, max: 131 },
-  { label: "Allegro", min: 132, max: 154 },
-  { label: "Vivace", min: 155, max: 176 },
-  { label: "Presto", min: 177, max: 200 },
-  { label: "Prestissimo", min: 201, max: 999 },
-];
+export const TEMPO_LABELS: TempoLabel[] = strings.metronome.tempoLabels;
 
 export const getTempoLabel = (bpm: number) => {
   const match = TEMPO_LABELS.find(

--- a/src/components/TickTock/TickTockAnimation.tsx
+++ b/src/components/TickTock/TickTockAnimation.tsx
@@ -1,8 +1,10 @@
 import { useTickTockVisualizer } from "../../hooks/useTickTockVisualizer";
+import strings from "../../strings.json";
 import { hoverPrompt, visualizer } from "./styles";
 
 const TickTockAnimation = () => {
   const { containerRef, isHorseHovered, isRunning } = useTickTockVisualizer();
+  const { hoverPrompt: hoverPromptLabel } = strings.tickTock;
 
   return (
     <div
@@ -12,7 +14,7 @@ const TickTockAnimation = () => {
       style={{ cursor: !isRunning && isHorseHovered ? "pointer" : "default" }}
     >
       {!isRunning && isHorseHovered ? (
-        <div className={hoverPrompt}>Wake Horsenome</div>
+        <div className={hoverPrompt}>{hoverPromptLabel}</div>
       ) : null}
     </div>
   );

--- a/src/strings.json
+++ b/src/strings.json
@@ -1,0 +1,193 @@
+{
+  "header": {
+    "brand": "Horsenome",
+    "quickHelp": {
+      "triggerAriaLabel": "about horsenome",
+      "dialog": {
+        "title": "About & Help",
+        "badgeLabel": "Our Story",
+        "description": "Horsenome was born from the organic cadence of a horse's gallop and the resonant warmth of the dholak. We believe rhythm should not be clinical. It should feel alive.",
+        "quickStart": {
+          "title": "Quick Start",
+          "items": [
+            "Slide the horizontal track to dial in your precise tempo from 40 to 220 BPM.",
+            "Select your taal or time signature through the chips to change the rhythmic cycle.",
+            "Open rhythm settings to add subdivisions like duple, triplet, quad, or swing when you want more internal pulse.",
+            "Tap the central pulse button to start the horse visualizer and sound."
+          ]
+        },
+        "supportCard": {
+          "title": "Made with Heart",
+          "body": "for musicians and the rhythmic practice community"
+        },
+        "actions": {
+          "feedbackLabel": "Issues",
+          "feedbackHref": "https://github.com/iamravisingh/horsenome/issues",
+          "supportLabel": "Feedback",
+          "supportHref": "mailto:ravisingh29091996@gmail.com"
+        },
+        "closeAriaLabel": "close about dialog"
+      }
+    }
+  },
+  "tickTock": {
+    "hoverPrompt": "Wake Horsenome"
+  },
+  "footer": {
+    "title": "\"Horsenome\" Made with ❤️",
+    "description": "Horsenome brings the rhythm of nature into music, inspired by the steady gallop of a horse 🐎 and the resonant beats of the dholak's thappi. Feel the rhythm, embrace the melody, and let your creativity flow!"
+  },
+  "metronome": {
+    "bpmCaption": "Beats Per Minute",
+    "visualizerFallback": "Loading visualizer",
+    "actionLabels": {
+      "volume": "Volume",
+      "haptic": "Haptic",
+      "timer": "Timer"
+    },
+    "bpmControl": {
+      "ariaLabel": "tempo"
+    },
+    "transport": {
+      "startAriaLabel": "start metronome",
+      "stopAriaLabel": "stop metronome",
+      "startAlt": "start",
+      "stopAlt": "stop"
+    },
+    "beatControl": {
+      "meterAriaLabel": "meter",
+      "custom": {
+        "toggleAriaLabel": "custom meter",
+        "beatsAriaLabel": "matras in cycle",
+        "unitAriaLabel": "beat unit",
+        "label": "Custom"
+      }
+    },
+    "rhythm": {
+      "defaultLabel": "Off",
+      "triggerTooltip": "Rhythm settings",
+      "triggerAriaLabel": "rhythm settings",
+      "drawerTitle": "Rhythm",
+      "selectorDialogTitle": "Select Rhythm",
+      "selectorCancelLabel": "Cancel",
+      "selectorConfirmLabel": "Confirm"
+    },
+    "history": {
+      "title": "History",
+      "description": "Recent tempo changes and playback actions.",
+      "initialLabel": "Ready",
+      "startedLabel": "Started",
+      "stoppedLabel": "Stopped",
+      "tempoUpdatedLabel": "Tempo updated",
+      "meterUpdatedLabel": "Meter updated",
+      "rhythmUpdatedLabel": "Rhythm updated"
+    },
+    "meterPresets": [
+      {
+        "label": "Teental",
+        "notation": "16 matras",
+        "westernNotation": "16/4",
+        "value": "teental",
+        "beats": 16,
+        "unit": 4,
+        "tradition": "hindustani"
+      },
+      {
+        "label": "Ektal",
+        "notation": "12 matras",
+        "westernNotation": "12/4",
+        "value": "ektal",
+        "beats": 12,
+        "unit": 4,
+        "tradition": "hindustani"
+      },
+      {
+        "label": "Jhaptal",
+        "notation": "10 matras",
+        "westernNotation": "10/4",
+        "value": "jhaptal",
+        "beats": 10,
+        "unit": 4,
+        "tradition": "hindustani"
+      },
+      {
+        "label": "Rupak",
+        "notation": "7 matras",
+        "westernNotation": "7/4",
+        "value": "rupak",
+        "beats": 7,
+        "unit": 4,
+        "tradition": "hindustani"
+      },
+      {
+        "label": "Dadra",
+        "notation": "6 matras",
+        "westernNotation": "6/4",
+        "value": "dadra",
+        "beats": 6,
+        "unit": 4,
+        "tradition": "hindustani"
+      },
+      {
+        "label": "Keharwa",
+        "notation": "8 matras",
+        "westernNotation": "8/4",
+        "value": "keharwa",
+        "beats": 8,
+        "unit": 4,
+        "tradition": "hindustani"
+      }
+    ],
+    "rhythmOptions": [
+      {
+        "value": "off",
+        "label": "Off",
+        "caption": "Main beats only"
+      },
+      {
+        "value": "duple",
+        "label": "Duple",
+        "caption": "2 pulses per beat"
+      },
+      {
+        "value": "triplet",
+        "label": "Triplet",
+        "caption": "3 pulses per beat"
+      },
+      {
+        "value": "quad",
+        "label": "Quad",
+        "caption": "4 pulses per beat"
+      },
+      {
+        "value": "swing",
+        "label": "Swing",
+        "caption": "Long-short feel"
+      }
+    ],
+    "tempoLabels": [
+      { "label": "Larghissimo", "min": 1, "max": 24 },
+      { "label": "Grave", "min": 25, "max": 39 },
+      { "label": "Largo", "min": 40, "max": 54 },
+      { "label": "Lento", "min": 55, "max": 63 },
+      { "label": "Adagio", "min": 64, "max": 72 },
+      { "label": "Andante", "min": 73, "max": 108 },
+      { "label": "Moderato", "min": 109, "max": 120 },
+      { "label": "Allegretto", "min": 121, "max": 131 },
+      { "label": "Allegro", "min": 132, "max": 154 },
+      { "label": "Vivace", "min": 155, "max": 176 },
+      { "label": "Presto", "min": 177, "max": 200 },
+      { "label": "Prestissimo", "min": 201, "max": 999 }
+    ]
+  },
+  "floatingButton": {
+    "addAriaLabel": "add",
+    "editAriaLabel": "edit"
+  },
+  "rhythmSelector": {
+    "title": "Select Rhythm",
+    "cancelLabel": "Cancel",
+    "confirmLabel": "Confirm",
+    "options": ["4/4", "3/4", "6/8", "7/8"]
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,6 +9,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",


### PR DESCRIPTION
- Redesigned the header help modal into a structured `About  & Help` dialog
  - Updated the dialog to use a responsive two-column layout on larger screens and a stacked layout on mobile
  - Added clearer sections for `Our Story`, `Quick Start`, and `Made with Heart`
  - Added quick-start guidance for tempo selection, taal/time signature selection, subdivisions, and playback
  - Improved the dialog close affordance with a dedicated top-right close button
  - Refined typography, spacing, and line length to prevent large text from breaking the layout
  - Updated the CTA row to use compact actions with clearer intent
  -  Changed CTA actions to:
    - `Issues` linking to GitHub issues
    - `Feedback` linking to email
  - Added tooltips so compact CTA labels remain understandable
  - Centralized the updated help-dialog copy in `src/strings.json`
  - Updated Cypress coverage to match the new dialog content