### PR TITLE
bug: fixed long-run engine for mobile and desktop

### DIFF
--- a/src/components/Metronome/MetronomeProvider/MetronomeProvider.tsx
+++ b/src/components/Metronome/MetronomeProvider/MetronomeProvider.tsx
@@ -29,6 +29,18 @@ const SUBDIVISION_VOLUME_RATIO = 0.32;
 const ENCOURAGEMENT_MILESTONE_SECONDS = 5 * 60;
 const DEFAULT_SESSION_SECONDS = 0;
 
+type WakeLockSentinelLike = {
+  release: () => Promise<void>;
+  addEventListener?: (type: "release", listener: () => void, options?: { once?: boolean }) => void;
+  removeEventListener?: (type: "release", listener: () => void) => void;
+};
+
+type WakeLockNavigator = Navigator & {
+  wakeLock?: {
+    request: (type: "screen") => Promise<WakeLockSentinelLike>;
+  };
+};
+
 export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const {
     initialLabel,
@@ -41,7 +53,8 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
   const {
     completionMessage,
     completionTitle,
-    encouragementBodies,
+    milestoneFallbackMessages,
+    milestoneMessages,
     milestoneTitleSuffix,
   } = strings.metronome.timerControl;
   const [bpm, setBpmState] = useState(120);
@@ -76,24 +89,42 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
   const sessionStartedAtRef = useRef<number | null>(null);
   const sessionCompletionShownRef = useRef(false);
   const lastMilestoneRef = useRef(0);
+  const wakeLockRef = useRef<WakeLockSentinelLike | null>(null);
   const encouragementAudioContextRef = useRef<AudioContext | null>(null);
   const rhythmPattern = getRhythmPattern(rhythmMode);
   const subdivisionCount = getSubdivisionCount(rhythmMode);
 
-  const tickSound = useRef(
-    new Howl({ src: ["/sounds/tick.mp3"], preload: true, html5: true })
-  ).current;
-  const tockSound = useRef(
-    new Howl({ src: ["/sounds/tock.mp3"], preload: true, html5: true })
-  ).current;
-  const subdivisionSound = useRef(
-    new Howl({
+  const tickSoundRef = useRef<Howl | null>(null);
+  if (!tickSoundRef.current) {
+    tickSoundRef.current = new Howl({
+      src: ["/sounds/tick.mp3"],
+      preload: true,
+      html5: true,
+    });
+  }
+
+  const tockSoundRef = useRef<Howl | null>(null);
+  if (!tockSoundRef.current) {
+    tockSoundRef.current = new Howl({
+      src: ["/sounds/tock.mp3"],
+      preload: true,
+      html5: true,
+    });
+  }
+
+  const subdivisionSoundRef = useRef<Howl | null>(null);
+  if (!subdivisionSoundRef.current) {
+    subdivisionSoundRef.current = new Howl({
       src: ["/sounds/tock.mp3"],
       preload: true,
       html5: true,
       volume: SUBDIVISION_VOLUME_RATIO,
-    })
-  ).current;
+    });
+  }
+
+  const tickSound = tickSoundRef.current;
+  const tockSound = tockSoundRef.current;
+  const subdivisionSound = subdivisionSoundRef.current;
 
   const pushHistory = useCallback((entry: Omit<HistoryEntry, "id">) => {
     const timestamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -167,10 +198,71 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
     [playEncouragementCue]
   );
 
+  const getMilestoneMessage = useCallback((minutes: number) => {
+    const exactMatch = milestoneMessages.find((entry) => entry.atMinutes === minutes);
+    if (exactMatch) {
+      return exactMatch.message;
+    }
+
+    const highestScriptedMilestone = milestoneMessages[milestoneMessages.length - 1]?.atMinutes ?? 0;
+    if (minutes > highestScriptedMilestone) {
+      const overflowStepIndex = Math.floor((minutes - highestScriptedMilestone - 1) / 5)
+        % milestoneFallbackMessages.length;
+      return milestoneFallbackMessages[overflowStepIndex] ?? milestoneFallbackMessages[0];
+    }
+
+    const lowerBoundMatch = [...milestoneMessages].reverse().find((entry) => minutes >= entry.atMinutes);
+
+    if (lowerBoundMatch) {
+      return lowerBoundMatch.message;
+    }
+
+    const fallbackIndex = Math.max(0, Math.floor(minutes / 5) - 1) % milestoneFallbackMessages.length;
+    return milestoneFallbackMessages[fallbackIndex] ?? milestoneFallbackMessages[0];
+  }, [milestoneFallbackMessages, milestoneMessages]);
+
   const clearPlaybackTimer = useCallback(() => {
-    if (timeoutRef.current) {
+    if (timeoutRef.current !== null) {
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
+    }
+  }, []);
+
+  const requestWakeLock = useCallback(async () => {
+    if (typeof document === "undefined" || document.visibilityState !== "visible") {
+      return;
+    }
+
+    const wakeLockNavigator = navigator as WakeLockNavigator;
+    if (!wakeLockNavigator.wakeLock || wakeLockRef.current) {
+      return;
+    }
+
+    try {
+      const wakeLock = await wakeLockNavigator.wakeLock.request("screen");
+      wakeLock.addEventListener?.("release", () => {
+        if (wakeLockRef.current === wakeLock) {
+          wakeLockRef.current = null;
+        }
+      }, { once: true });
+      wakeLockRef.current = wakeLock;
+    } catch {
+      wakeLockRef.current = null;
+    }
+  }, []);
+
+  const releaseWakeLock = useCallback(async () => {
+    const currentWakeLock = wakeLockRef.current;
+    wakeLockRef.current = null;
+
+    if (!currentWakeLock) {
+      return;
+    }
+
+    try {
+      await currentWakeLock.release();
+    } catch {
+      // Ignore release failures. A stale sentinel is harmless once cleared locally.
     }
   }, []);
 
@@ -211,6 +303,7 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
         detail: getPlaybackDetail(timeSignature.beats, timeSignature.unit, bpm, rhythmMode),
         tone: "neutral",
       });
+      void releaseWakeLock();
     },
     [
       bpm,
@@ -219,6 +312,7 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
       pushHistory,
       resetSessionProgress,
       rhythmMode,
+      releaseWakeLock,
       stoppedLabel,
       timeSignature.beats,
       timeSignature.unit,
@@ -254,8 +348,7 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
       const minutes = nextElapsed / 60;
       if (minutes !== lastMilestoneRef.current) {
         lastMilestoneRef.current = minutes;
-        const bodyIndex = (Math.floor(minutes / 5) - 1) % encouragementBodies.length;
-        const body = encouragementBodies[bodyIndex] ?? encouragementBodies[0];
+        const body = getMilestoneMessage(minutes);
         showEncouragement("milestone", `${minutes} ${milestoneTitleSuffix}`, body);
       }
     }
@@ -276,16 +369,14 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
   }, [
     completionMessage,
     completionTitle,
-    encouragementBodies,
+    getMilestoneMessage,
     milestoneTitleSuffix,
     showEncouragement,
   ]);
 
   const playPulse = useCallback(() => {
     const pulseTimestamp = performance.now();
-    if (syncSessionProgress(pulseTimestamp)) {
-      return;
-    }
+    syncSessionProgress(pulseTimestamp);
 
     const subdivisionIndex = subdivisionStepRef.current;
     const isSubdivision = subdivisionIndex > 0;
@@ -347,12 +438,14 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
       detail: getPlaybackDetail(timeSignature.beats, timeSignature.unit, bpm, rhythmMode),
       tone: "success",
     });
+    void requestWakeLock();
   }, [
     bpm,
     getPlaybackDetail,
     isRunning,
     playPulse,
     pushHistory,
+    requestWakeLock,
     rhythmMode,
     resetSessionProgress,
     scheduleNextPulse,
@@ -456,11 +549,36 @@ export const MetronomeProvider: FC<{ children: ReactNode }> = ({ children }) => 
 
   useEffect(() => {
     return () => {
+      void releaseWakeLock();
       if (encouragementAudioContextRef.current) {
         void encouragementAudioContextRef.current.close();
       }
     };
-  }, []);
+  }, [releaseWakeLock]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return undefined;
+    }
+
+    const handleVisibilityChange = () => {
+      if (!isRunning) {
+        return;
+      }
+
+      if (document.visibilityState === "visible") {
+        void requestWakeLock();
+        return;
+      }
+
+      void releaseWakeLock();
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [isRunning, releaseWakeLock, requestWakeLock, scheduleNextPulse]);
 
   return (
     <metronomeContext.Provider

--- a/src/components/Metronome/PracticeSessionStatus.tsx
+++ b/src/components/Metronome/PracticeSessionStatus.tsx
@@ -36,7 +36,7 @@ const confettiPiece = css`
   will-change: transform, opacity;
 `;
 
-const confettiPieces = [
+const completionConfettiPieces = [
   { left: "8vw", width: 10, height: 18, color: "#3b6934", rotate: -18, delay: 0 },
   { left: "14vw", width: 9, height: 9, color: "#efd48b", rotate: 16, delay: 0.08 },
   { left: "23vw", width: 8, height: 16, color: "#a5d898", rotate: -10, delay: 0.15 },
@@ -59,6 +59,17 @@ const confettiPieces = [
   { left: "96vw", width: 9, height: 15, color: "#c8e1c1", rotate: -18, delay: 0.21 },
 ] as const;
 
+const milestoneConfettiPieces = [
+  { left: "10vw", width: 8, height: 14, color: "#3b6934", rotate: -14, delay: 0 },
+  { left: "22vw", width: 7, height: 12, color: "#efd48b", rotate: 18, delay: 0.06 },
+  { left: "34vw", width: 8, height: 8, color: "#a5d898", rotate: -8, delay: 0.12 },
+  { left: "46vw", width: 9, height: 15, color: "#3b6934", rotate: 24, delay: 0.04 },
+  { left: "58vw", width: 7, height: 11, color: "#c8e1c1", rotate: -12, delay: 0.1 },
+  { left: "70vw", width: 8, height: 14, color: "#efd48b", rotate: 14, delay: 0.15 },
+  { left: "82vw", width: 9, height: 9, color: "#a5d898", rotate: -18, delay: 0.08 },
+  { left: "92vw", width: 8, height: 13, color: "#3b6934", rotate: 16, delay: 0.18 },
+] as const;
+
 const formatCountdown = (totalSeconds: number) => {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
@@ -69,6 +80,8 @@ const PracticeSessionStatus = () => {
   const { countdownSuffix } = strings.metronome.timerControl;
   const { dismissEncouragement, encouragementNotice, isRunning, remainingSeconds } = useMetronome();
   const isCompletion = encouragementNotice?.kind === "completion";
+  const shouldShowConfetti = Boolean(encouragementNotice);
+  const confettiPieces = isCompletion ? completionConfettiPieces : milestoneConfettiPieces;
   const countdownLabel = useMemo(() => {
     if (!isRunning || remainingSeconds === null) {
       return null;
@@ -126,7 +139,7 @@ const PracticeSessionStatus = () => {
         ) : null}
       </AnimatePresence>
 
-      {isCompletion && encouragementNotice ? (
+      {shouldShowConfetti && encouragementNotice ? (
         <>
           <div className={celebrationOverlay} data-testid="completion-celebration" aria-hidden="true">
             {confettiPieces.map((piece, index) => (
@@ -142,13 +155,15 @@ const PracticeSessionStatus = () => {
                 initial={{ opacity: 0, y: -24, rotate: piece.rotate, scale: 0.72 }}
                 animate={{
                   opacity: [0, 1, 1, 0],
-                  y: [-24, 110, 280, 540],
+                  y: isCompletion ? [-24, 110, 280, 540] : [-24, 90, 210, 380],
                   x: [0, index % 2 === 0 ? -18 : 18, index % 2 === 0 ? 12 : -12],
-                  rotate: [piece.rotate, piece.rotate + 110, piece.rotate + 220],
-                  scale: [0.72, 1, 0.92],
+                  rotate: isCompletion
+                    ? [piece.rotate, piece.rotate + 110, piece.rotate + 220]
+                    : [piece.rotate, piece.rotate + 70, piece.rotate + 120],
+                  scale: isCompletion ? [0.72, 1, 0.92] : [0.72, 0.94, 0.86],
                 }}
                 transition={{
-                  duration: 3,
+                  duration: isCompletion ? 3 : 2.2,
                   delay: piece.delay,
                   ease: "easeOut",
                 }}

--- a/src/strings.json
+++ b/src/strings.json
@@ -65,11 +65,18 @@
       "completionTitle": "Session complete",
       "completionMessage": "Strong work. Take a breath and go again when ready.",
       "milestoneTitleSuffix": "minutes in",
-      "encouragementBodies": [
-        "Strong work. Keep the pulse steady.",
-        "You are locked in. Stay with the groove.",
-        "Nice consistency. Let the rhythm breathe.",
-        "You are doing great. Keep going."
+      "milestoneMessages": [
+        { "atMinutes": 5, "message": "Five minutes in. The pulse is settling under your hands." },
+        { "atMinutes": 10, "message": "Ten minutes in. Stay loose and keep the groove breathing." },
+        { "atMinutes": 15, "message": "Fifteen minutes in. Your consistency is doing the work now." },
+        { "atMinutes": 20, "message": "Twenty minutes in. Hold the center and keep the cycle clean." },
+        { "atMinutes": 25, "message": "Twenty-five minutes in. The focus is there. Keep it steady." },
+        { "atMinutes": 30, "message": "Thirty minutes in. Strong practice. Let the rhythm keep opening up." }
+      ],
+      "milestoneFallbackMessages": [
+        "Keep going. The pulse is staying with you.",
+        "Good work. Stay patient and keep the cycle even.",
+        "You are in it now. Let the groove keep breathing."
       ]
     },
     "bpmControl": {


### PR DESCRIPTION
  - Removed the broken Web Audio scheduler rewrite that caused missing inner beats
  - Fixed Howl initialization so audio instances are created once and not on every render
  - Kept wake-lock support to reduce mobile screen-sleep interruptions during practice
  - Added confetti for 5-minute milestone encouragements as well as session completion
  - Reworked timer encouragement copy to use time-aware milestone messages
  - Added fallback milestone messaging for sessions longer than 30 minutes
  - Fixed wake-lock revocation handling so supported browsers can reacquire the lock mid-session